### PR TITLE
fix: stack note nav prev/next vertically on mobile

### DIFF
--- a/src/routes/notes/[slug]/_components/note-nav.svelte
+++ b/src/routes/notes/[slug]/_components/note-nav.svelte
@@ -17,7 +17,7 @@
   {@const isPrev = direction === "prev"}
   <a
     href="/notes/{note.slug}"
-    class="group text-muted hover:text-foreground relative isolate flex min-w-0 flex-1 flex-col gap-1 rounded-lg p-4 transition-colors duration-200
+    class="group text-muted hover:text-foreground relative isolate flex min-w-0 flex-col gap-1 rounded-lg p-4 transition-colors duration-200 sm:flex-1
       {isPrev ? '' : 'items-end'}"
   >
     <!-- hover時の背景グラデーション -->
@@ -48,16 +48,18 @@
 {/snippet}
 
 {#if prevNote || nextNote}
-  <div class="mt-16 flex items-stretch justify-between gap-4">
+  <div
+    class="mt-16 flex flex-col gap-4 sm:flex-row sm:items-stretch sm:justify-between"
+  >
     {#if prevNote}
       {@render navItem(prevNote, "prev")}
     {:else}
-      <div class="flex-1"></div>
+      <div class="hidden sm:block sm:flex-1"></div>
     {/if}
     {#if nextNote}
       {@render navItem(nextNote, "next")}
     {:else}
-      <div class="flex-1"></div>
+      <div class="hidden sm:block sm:flex-1"></div>
     {/if}
   </div>
 {/if}


### PR DESCRIPTION
## Summary
- スマホ幅で notes/[slug] ページの prev/next ボタンが横並びだとタイトル文字が衝突・潰れる問題を修正にゃ
- `sm:` 未満では縦並び（prev → next の順）、`sm:` 以上では従来どおり横並びにレイアウト切替
- 左右の寄せ（prev は左、next は右）はそのまま維持

## Test plan
- [ ] `pnpm run dev` で notes/[slug] ページをスマホ幅（< 640px）で開き、prev/next が縦に並ぶことを確認
- [ ] スマホ幅で prev は左寄せ、next は右寄せのままになっていることを確認
- [ ] sm 以上の幅では従来どおり横並びであることを確認
- [ ] prev のみ / next のみ / 両方ある の各ケースで表示崩れがないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)